### PR TITLE
modified wsfed error handling, also return string errors

### DIFF
--- a/wsfed/response.go
+++ b/wsfed/response.go
@@ -67,7 +67,7 @@ func (p *WsFederation) decodeResponse(resp []byte, opts *tokenParseOptions) (*To
 			return nil, ErrTokenSignatureInvalid
 		}
 
-		return nil, ErrTokenSignatureInvalid
+		return nil, err
 	}
 
 	var raw, signature, validatedRaw string


### PR DESCRIPTION
In order to enhance debugging and logging capabilities, this update modifies the WS-Federation error handling mechanism to return string errors directly when validation failures occur.

Previously, specific error messages such as `errors.New("Cert is not valid at this time")` were not propagated to the application logs, making it difficult to diagnose issues promptly. With this change, these specific error messages will be returned as-is, allowing them to be accurately captured in the application logs.