### PR TITLE
Fix memory leak on metrics endpoint

### DIFF
--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -21,6 +21,8 @@ type metricsHandler struct {
 	reqCnt            *prometheus.CounterVec
 	reqDur            *prometheus.HistogramVec
 	reqSize, respSize prometheus.Summary
+	// Cached fasthttp handler for serving Prometheus metrics
+	httpHandler fasthttp.RequestHandler
 	// Metrics path
 	MetricsPath string
 	// Subsystem
@@ -47,6 +49,7 @@ func Metrics(path string, options ...MetricsOption) azugo.RequestHandlerFunc {
 	}
 
 	p.registerMetrics()
+	p.httpHandler = fasthttpadaptor.NewFastHTTPHandler(promhttp.Handler())
 
 	return p.Handler
 }
@@ -80,11 +83,13 @@ func computeApproximateRequestSize(req *fasthttp.Request, out chan int) {
 // Handles MetricsPath requests from trusted IPs and trusted networks
 // which returns application metrics results.
 func (p *metricsHandler) Handler(h azugo.RequestHandler) azugo.RequestHandler {
-	metricsHandler := fasthttpadaptor.NewFastHTTPHandler(promhttp.Handler())
-
 	return func(ctx *azugo.Context) {
-		if strings.EqualFold(ctx.Path(), p.MetricsPath) && p.isTrusted(ctx) {
-			metricsHandler(ctx.Context())
+		if strings.EqualFold(ctx.Path(), p.MetricsPath) {
+			if p.isTrusted(ctx) {
+				p.httpHandler(ctx.Context())
+			} else {
+				h(ctx)
+			}
 
 			return
 		}
@@ -97,7 +102,7 @@ func (p *metricsHandler) Handler(h azugo.RequestHandler) azugo.RequestHandler {
 			}
 		}
 
-		reqSize := make(chan int)
+		reqSize := make(chan int, 1)
 		frc := acquireRequestFromPool()
 		ctx.Request().CopyTo(frc)
 


### PR DESCRIPTION
Root cause: goroutine leak on every 404 response                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                             
  The metrics middleware spawns a background goroutine to compute request size and sends the result over an unbuffered channel:                                                                                                                                              
                                                                                                                                                                                                                                                                             
```
  reqSize := make(chan int)                                                                                                                                                                                                                                                
  go func() {                                                                                                                                                                                                                                                                
      computeApproximateRequestSize(frc, reqSize) // blocks at: out <- s
  }()                                                                                                                                                                                                                                                                        
  h(ctx)
  if status == fasthttp.StatusNotFound {                                                                                                                                                                                                                                     
      return // nobody ever reads from reqSize — goroutine blocked forever                                                                                                                                                                                                 
  }                                                                                                                                                                                                                                                                        
  p.reqSize.Observe(float64(<-reqSize))
```
                                                                                                                                                                                                                                                                             
  For every 404 response the goroutine is permanently stuck waiting to send, leaking itself and a full copy of the HTTP request.
                                                                                                                                                                                                                                                                             
  This includes the /metrics path itself: because no route is registered for it, every Prometheus scrape goes through the 404 handler chain. Even with METRICS_TRUSTED_IPS: * the scrape succeeds (the trusted check returns early before the goroutine code), but any other 
  404 — Kubernetes health probes hitting a wrong path, bots, stale client URLs — leaks a goroutine. Over hours or days the accumulation causes the observed memory growth.                                                                                                 
                                                                                                                                                                                                                                                                             
  A secondary issue: because the 404 chain is rebuilt on every request (mux.WrapHandler("", m.Chain(m.HandleNotFound))(ctx)), the fasthttpadaptor wrapping promhttp.Handler() was also re-created on every single scrape.                                                    
                                                                                                                                                                                                                                                                           
  Fix                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                           
  1. Buffered channel (make(chan int, 1)) — the goroutine always completes regardless of whether the main handler reads from the channel, eliminating the leak for all 404 responses.                                                                                      
  2. Short-circuit the metrics path before spawning the goroutine — the metrics path is now fully handled (trusted → serve metrics, untrusted → pass to next handler) before any goroutine is started, so the metrics endpoint itself can never contribute to the leak.
  3. Cache httpHandler in the struct — fasthttpadaptor.NewFastHTTPHandler(promhttp.Handler()) is created once at startup instead of once per request.              