### PR TITLE
fix: measure request duration from request start, not connection time

### DIFF
--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -92,7 +92,7 @@ func (p *metricsHandler) Handler(h azugo.RequestHandler) azugo.RequestHandler {
 			return
 		}
 
-		elapsed := float64(time.Since(ctx.StartTime())) / float64(time.Second)
+		elapsed := float64(time.Since(ctx.Context().Time())) / float64(time.Second)
 
 		var respSize float64
 

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -92,7 +92,7 @@ func (p *metricsHandler) Handler(h azugo.RequestHandler) azugo.RequestHandler {
 			return
 		}
 
-		elapsed := float64(time.Since(ctx.Context().ConnTime())) / float64(time.Second)
+		elapsed := float64(time.Since(ctx.StartTime())) / float64(time.Second)
 
 		var respSize float64
 

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -35,11 +35,9 @@ func RequestLogger(next azugo.RequestHandler) azugo.RequestHandler {
 		})
 		ctx.SetUserValue("__log_request", enabled)
 
-		t1 := time.Now()
-
 		next(ctx)
 
-		ns := time.Since(t1).Nanoseconds()
+		ns := time.Since(ctx.StartTime()).Nanoseconds()
 
 		if ctx.IsSkipRequestLog() {
 			return
@@ -69,7 +67,7 @@ func RequestLogger(next azugo.RequestHandler) azugo.RequestHandler {
 
 		// Request time
 		_, _ = msg.Write([]byte(" ["))
-		_, _ = msg.WriteString(t1.Format("02/Jan/2006:15:04:05 -0700"))
+		_, _ = msg.WriteString(ctx.StartTime().Format("02/Jan/2006:15:04:05 -0700"))
 		_, _ = msg.Write([]byte("] \""))
 
 		// Method

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -37,7 +37,7 @@ func RequestLogger(next azugo.RequestHandler) azugo.RequestHandler {
 
 		next(ctx)
 
-		ns := time.Since(ctx.StartTime()).Nanoseconds()
+		ns := time.Since(ctx.Context().Time()).Nanoseconds()
 
 		if ctx.IsSkipRequestLog() {
 			return
@@ -67,7 +67,7 @@ func RequestLogger(next azugo.RequestHandler) azugo.RequestHandler {
 
 		// Request time
 		_, _ = msg.Write([]byte(" ["))
-		_, _ = msg.WriteString(ctx.StartTime().Format("02/Jan/2006:15:04:05 -0700"))
+		_, _ = msg.WriteString(ctx.Context().Time().Format("02/Jan/2006:15:04:05 -0700"))
 		_, _ = msg.Write([]byte("] \""))
 
 		// Method

--- a/request.go
+++ b/request.go
@@ -46,6 +46,7 @@ type Context struct {
 	path       string    // HTTP path with the modifications by the configuration -> string copy from pathBuffer
 	routerPath string    // HTTP path as registered in the router
 	requestID  ulid.ULID // Request ID
+	startTime  time.Time // Time the request started being processed
 
 	// Core data
 	app  *App
@@ -125,8 +126,10 @@ func (a *App) acquireCtx(m *mux, path string, c *fasthttp.RequestCtx) *Context {
 		}
 	}
 
+	ctx.startTime = time.Now()
+
 	// Ignore error
-	ctx.requestID, _ = ulid.New(ulid.Timestamp(time.Now().UTC()), a.entropy)
+	ctx.requestID, _ = ulid.New(ulid.Timestamp(ctx.startTime.UTC()), a.entropy)
 
 	// Attach base fastHTTP request context
 	ctx.context = c
@@ -182,6 +185,7 @@ func (c *Context) reset() {
 	c.loggerCore = nil
 	c.logger = nil
 	c.requestID = nilRequestID
+	c.startTime = time.Time{}
 	c.alwaysHeaders = c.alwaysHeaders[:0]
 }
 
@@ -204,6 +208,14 @@ func (c *Context) RouterOptions() *RouterOptions {
 // a cancellation signal, and other values across API boundaries.
 func (c *Context) Context() *fasthttp.RequestCtx {
 	return c.context
+}
+
+// StartTime returns the time the request started being processed.
+//
+// Unlike fasthttp's ConnTime, this is set once per request, so it is accurate
+// for requests served over reused keep-alive connections.
+func (c *Context) StartTime() time.Time {
+	return c.startTime
 }
 
 // Request return the *fasthttp.Request object

--- a/request.go
+++ b/request.go
@@ -46,7 +46,6 @@ type Context struct {
 	path       string    // HTTP path with the modifications by the configuration -> string copy from pathBuffer
 	routerPath string    // HTTP path as registered in the router
 	requestID  ulid.ULID // Request ID
-	startTime  time.Time // Time the request started being processed
 
 	// Core data
 	app  *App
@@ -126,10 +125,8 @@ func (a *App) acquireCtx(m *mux, path string, c *fasthttp.RequestCtx) *Context {
 		}
 	}
 
-	ctx.startTime = time.Now()
-
 	// Ignore error
-	ctx.requestID, _ = ulid.New(ulid.Timestamp(ctx.startTime.UTC()), a.entropy)
+	ctx.requestID, _ = ulid.New(ulid.Timestamp(time.Now().UTC()), a.entropy)
 
 	// Attach base fastHTTP request context
 	ctx.context = c
@@ -185,7 +182,6 @@ func (c *Context) reset() {
 	c.loggerCore = nil
 	c.logger = nil
 	c.requestID = nilRequestID
-	c.startTime = time.Time{}
 	c.alwaysHeaders = c.alwaysHeaders[:0]
 }
 
@@ -208,14 +204,6 @@ func (c *Context) RouterOptions() *RouterOptions {
 // a cancellation signal, and other values across API boundaries.
 func (c *Context) Context() *fasthttp.RequestCtx {
 	return c.context
-}
-
-// StartTime returns the time the request started being processed.
-//
-// Unlike fasthttp's ConnTime, this is set once per request, so it is accurate
-// for requests served over reused keep-alive connections.
-func (c *Context) StartTime() time.Time {
-	return c.startTime
 }
 
 // Request return the *fasthttp.Request object


### PR DESCRIPTION
The metrics middleware computed request_duration_seconds from fasthttp ConnTime(), which is set once when the TCP connection is accepted and never reset per request. On reused keep-alive connections every request after the first was timed from the connection's open instant, inflating durations by the whole connection age. The error only showed on APIs whose clients reuse connections; one-request-per-connection traffic happened to read correctly.

Stamp a per-request startTime in acquireCtx and expose Context.StartTime(). Metrics and the request logger now both measure from this single anchor, so the metric is accurate over keep-alive and matches the access log.